### PR TITLE
Fix missing tkinter import

### DIFF
--- a/Yonky_0.9.py
+++ b/Yonky_0.9.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import tkinter as tk
-from tkinter import ttk, messagebox, filedialog, scrolledtext
+from tkinter import ttk, messagebox, filedialog, scrolledtext, simpledialog
 import threading
 import json
 import time


### PR DESCRIPTION
## Summary
- include `simpledialog` in tkinter imports
- ensure the main script ends with a newline

## Testing
- `python3 -m py_compile Yonky_0.9.py`


------
https://chatgpt.com/codex/tasks/task_e_68666dc8efe48333ae6c2784b7959a10