### PR TITLE
Fix scripts directory path for packaged mode

### DIFF
--- a/Yonky_0.9.py
+++ b/Yonky_0.9.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import subprocess
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog, scrolledtext, simpledialog
@@ -7,8 +8,13 @@ import json
 import time
 from datetime import datetime
 
-SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "scripts")
-CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.json")
+if getattr(sys, "frozen", False):
+    BASE_DIR = os.path.dirname(sys.executable)
+else:
+    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+SCRIPTS_DIR = os.path.join(BASE_DIR, "scripts")
+CONFIG_FILE = os.path.join(BASE_DIR, "config.json")
 
 
 class PreferencesDialog(tk.Toplevel):


### PR DESCRIPTION
## Summary
- detect runtime base directory using `sys.frozen` to handle packaged executables
- build `SCRIPTS_DIR` and `CONFIG_FILE` relative to base directory

## Testing
- `python -m py_compile Yonky_0.9.py`

------
https://chatgpt.com/codex/tasks/task_e_6867c6ffefc48333a1cc251855eae69a