### PR TITLE
Enhance script metadata handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the official EXE release.
 📦 What’s in the ZIP
 ------------------------------
 - Yonky.exe             --> The launcher (compiled EXE)
-- config.json           --> Optional script metadata
+ - config.json           --> Optional launcher settings & script metadata
 - /scripts/             --> Place your PowerShell (.ps1) scripts here
 - README.txt            --> This file
 
@@ -23,7 +23,7 @@ This is the official EXE release.
 1. **Extract** the ZIP to a local folder (e.g. `C:\Yonky\`)
 2. **Double-click `Yonky.exe`** to launch the GUI
 3. Add your scripts to the `/scripts/` folder
-4. Edit `config.json` to set friendly names and descriptions
+4. Edit `config.json` to set friendly names and descriptions under the `scripts` section
 
 The launcher will auto-detect available `.ps1` files and display them with names, descriptions, and a “Run” button for each.
 
@@ -31,13 +31,16 @@ The launcher will auto-detect available `.ps1` files and display them with names
 🧠 Example config.json
 ------------------------------
 {
-  "Cleanup.ps1": {
-    "name": "Clean Temp Folders",
-    "description": "Deletes temp files older than 7 days."
+  "scripts": {
+    "Cleanup.ps1": {
+      "name": "Clean Temp Folders",
+      "description": "Deletes temp files older than 7 days."
+    }
   }
 }
 
-This file is optional. If it's missing, Yonky will simply list scripts by filename.
+This file is optional. If it's missing, Yonky scans the `scripts` folder and
+generates entries automatically using each filename.
 
 ------------------------------
 

--- a/Yonky_0.9.py
+++ b/Yonky_0.9.py
@@ -71,6 +71,7 @@ class ScriptLauncherApp(tk.Tk):
         
         self.setup_menu()
         self.setup_ui()
+        self.load_scripts_from_config()
         self.load_scripts()
         
         # Bind close event
@@ -82,20 +83,49 @@ class ScriptLauncherApp(tk.Tk):
             "recent_scripts": [],
             "auto_scroll": True,
             "show_timestamps": True,
-            "execution_policy": "Bypass"
+            "execution_policy": "Bypass",
+            "scripts": {}
         }
-        
+
+        data = {}
         if os.path.exists(CONFIG_FILE):
             try:
                 with open(CONFIG_FILE, 'r') as f:
-                    return {**default_config, **json.load(f)}
-            except:
-                return default_config
-        return default_config
+                    data = json.load(f)
+            except Exception:
+                data = {}
+
+        config = {**default_config, **data}
+
+        if not config.get("scripts"):
+            scripts = {}
+            if os.path.exists(SCRIPTS_DIR):
+                for f in os.listdir(SCRIPTS_DIR):
+                    if f.endswith((".ps1", ".bat", ".cmd")):
+                        scripts[f] = {"name": f, "description": ""}
+            config["scripts"] = scripts
+
+        return config
 
     def save_config(self):
         """Save application configuration"""
         try:
+            scripts_meta = self.config_data.get("scripts", {})
+
+            if os.path.exists(SCRIPTS_DIR):
+                files = [f for f in os.listdir(SCRIPTS_DIR)
+                         if f.endswith((".ps1", ".bat", ".cmd"))]
+
+                for f in files:
+                    if f not in scripts_meta:
+                        scripts_meta[f] = {"name": f, "description": ""}
+
+                for key in list(scripts_meta.keys()):
+                    if key not in files:
+                        del scripts_meta[key]
+
+            self.config_data["scripts"] = scripts_meta
+
             with open(CONFIG_FILE, 'w') as f:
                 json.dump(self.config_data, f, indent=2)
         except Exception as e:
@@ -295,7 +325,7 @@ class ScriptLauncherApp(tk.Tk):
         """Edit the currently selected script"""
         selection = self.script_tree.selection()
         if selection:
-            script_name = self.script_tree.item(selection[0])['values'][0]
+            script_name = selection[0]
             self.edit_script(script_name)
 
     def clear_output(self):
@@ -313,32 +343,54 @@ class ScriptLauncherApp(tk.Tk):
         except Exception as e:
             self.log_output(f"Could not copy output: {e}", "error")
 
-    def load_scripts(self):
-        """Load and display available scripts"""
-        # Clear existing items
+    def load_scripts_from_config(self):
+        """Populate the tree view from stored config"""
         for item in self.script_tree.get_children():
             self.script_tree.delete(item)
-        
+
+        scripts = self.config_data.get("scripts", {})
+        count = 0
+        for fname, meta in scripts.items():
+            script_path = os.path.join(SCRIPTS_DIR, fname)
+            if not os.path.exists(script_path):
+                continue
+            try:
+                stat = os.stat(script_path)
+                modified = datetime.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d %H:%M")
+                size = f"{stat.st_size / 1024:.1f}"
+            except Exception:
+                modified = "Error"
+                size = "0"
+
+            display_name = meta.get("name", fname)
+            self.script_tree.insert('', tk.END, iid=fname, values=(display_name, modified, size))
+            count += 1
+
+        self.status_label.config(text=f"{count} scripts loaded")
+
+    def load_scripts(self):
+        """Synchronize config with filesystem and refresh view"""
         if not os.path.exists(SCRIPTS_DIR):
             return
-            
+
+        scripts_meta = self.config_data.get("scripts", {})
+
         try:
-            scripts = [f for f in os.listdir(SCRIPTS_DIR) 
-                      if f.endswith(('.ps1', '.bat', '.cmd'))]
-            
-            for script in sorted(scripts):
-                script_path = os.path.join(SCRIPTS_DIR, script)
-                try:
-                    stat = os.stat(script_path)
-                    modified = datetime.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d %H:%M")
-                    size = f"{stat.st_size / 1024:.1f}"
-                    
-                    self.script_tree.insert('', tk.END, values=(script, modified, size))
-                except Exception as e:
-                    self.script_tree.insert('', tk.END, values=(script, "Error", "0"))
-            
-            self.status_label.config(text=f"{len(scripts)} scripts loaded")
-            
+            files = [f for f in os.listdir(SCRIPTS_DIR)
+                     if f.endswith((".ps1", ".bat", ".cmd"))]
+
+            for f in files:
+                if f not in scripts_meta:
+                    scripts_meta[f] = {"name": f, "description": ""}
+
+            for key in list(scripts_meta.keys()):
+                if key not in files:
+                    del scripts_meta[key]
+
+            self.config_data["scripts"] = scripts_meta
+            self.save_config()
+            self.load_scripts_from_config()
+
         except Exception as e:
             self.log_output(f"Error loading scripts: {e}", "error")
 
@@ -348,8 +400,8 @@ class ScriptLauncherApp(tk.Tk):
         if not selection:
             messagebox.showwarning("No Selection", "Please select a script to run")
             return
-        
-        script_name = self.script_tree.item(selection[0])['values'][0]
+
+        script_name = selection[0]
         self.run_script_thread(script_name)
 
     def delete_selected_script(self):
@@ -358,8 +410,8 @@ class ScriptLauncherApp(tk.Tk):
         if not selection:
             messagebox.showwarning("No Selection", "Please select a script to delete")
             return
-        
-        script_name = self.script_tree.item(selection[0])['values'][0]
+
+        script_name = selection[0]
         self.delete_script(script_name)
 
     def run_script_thread(self, script_name):

--- a/config.json
+++ b/config.json
@@ -2,5 +2,15 @@
   "recent_scripts": [],
   "auto_scroll": true,
   "show_timestamps": true,
-  "execution_policy": "Bypass"
+  "execution_policy": "Bypass",
+  "scripts": {
+    "check-cpu.ps1": {
+      "name": "check-cpu.ps1",
+      "description": ""
+    },
+    "test-tone.ps1": {
+      "name": "test-tone.ps1",
+      "description": ""
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- extend config loading to create a `scripts` dictionary when missing
- ensure config is saved with any new script entries
- add `load_scripts_from_config` and show friendly names from config
- refresh GUI after config load and on startup
- document new `scripts` section in README
- update sample config.json

## Testing
- `python -m py_compile Yonky_0.9.py`


------
https://chatgpt.com/codex/tasks/task_e_686b83fbcbc083339dc6ccb32b02962e