### PR TITLE
Add persistent script metadata management

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
   "recent_scripts": [],
   "auto_scroll": true,
   "show_timestamps": true,
-  "execution_policy": "Bypass"
+  "execution_policy": "Bypass",
+  "scripts": {}
 }


### PR DESCRIPTION
## Summary
- extend default config with a `scripts` dictionary
- parse script metadata via new `load_scripts_from_config`
- merge config-defined scripts with auto-detected ones
- persist new/removed scripts to the config file

## Testing
- `python -m py_compile Yonky_0.9.py`

------
https://chatgpt.com/codex/tasks/task_e_686b8408b0a883339eb52e23db3c1af6